### PR TITLE
always show "read page" form, only mark displayed entries as read

### DIFF
--- a/feedhq/core/static/core/js/feedhq.js
+++ b/feedhq/core/static/core/js/feedhq.js
@@ -45,10 +45,6 @@
 			};
 			update_ids();
 
-			if (!$('[data-next]').length) {
-				$('#id_entries').parent('form').hide();
-			}
-
 			$('.feedhq-more').click(function(event) {
 				event.preventDefault();
 				var link = $(this),


### PR DESCRIPTION
This prevents from mass-marking as read entries that were created by the time the user submit the "read all" form.
