### PR TITLE
Updating Django to the latest 1.6.x

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django==1.6.5
+Django==1.6.7
 Pillow==2.4.0
 South==0.8.4
 URLObject==2.3.4


### PR DESCRIPTION
Django had a [security release](https://www.djangoproject.com/weblog/2014/aug/20/security/) issued that summer and FeedHQ might be exposed if not up-to-date.
