### PR TITLE
Add rel=prev/next to navigation links

### DIFF
--- a/feedhq/feeds/templates/feeds/entry_navigation.html
+++ b/feedhq/feeds/templates/feeds/entry_navigation.html
@@ -1,6 +1,6 @@
 <div class="figures detail{% if place %} {{ place }}{% endif %}">
 	<div class="pagination">
-		{% if previous %}<a data-mousetrap="k,left" class="feedhq-previous" href="{{ previous }}">← {% if mode == "unread" %}{% trans "Previous unread" %}{% else %}{% trans "Previous" %}{% endif %}</a>{% endif %}
-		{% if next %}<a data-mousetrap="j,right" class="feedhq-next" href="{{ next }}">{% if mode == "unread" %}{% trans "Next unread" %}{% else %}{% trans "Next" %}{% endif %} →</a>{% endif %}
+		{% if previous %}<a rel="prev" data-mousetrap="k,left" class="feedhq-previous" href="{{ previous }}">← {% if mode == "unread" %}{% trans "Previous unread" %}{% else %}{% trans "Previous" %}{% endif %}</a>{% endif %}
+		{% if next %}<a rel="next" data-mousetrap="j,right" class="feedhq-next" href="{{ next }}">{% if mode == "unread" %}{% trans "Next unread" %}{% else %}{% trans "Next" %}{% endif %} →</a>{% endif %}
 	</div>
 </div>

--- a/feedhq/feeds/templates/feeds/paginator.html
+++ b/feedhq/feeds/templates/feeds/paginator.html
@@ -2,7 +2,7 @@
 	{% if entries.paginator.num_pages > 1 %}
 		{% if entries.has_previous %}
 			{% if entries.previous_page_number == 1 %}
-				<a href="{{ base_url }}">{{ entries.previous_page_number }}</a>
+				<a rel="prev" href="{{ base_url }}">{{ entries.previous_page_number }}</a>
 			{% else %}
 				<a href="{{ base_url }}">1</a>
 				{% if entries.previous_page_number != 2 %}
@@ -12,7 +12,7 @@
 						<span>…</span>
 					{% endif %}
 				{% endif %}
-				<a href="{{ base_url }}{{ entries.previous_page_number }}/">{{ entries.previous_page_number }}</a>
+				<a rel="prev" href="{{ base_url }}{{ entries.previous_page_number }}/">{{ entries.previous_page_number }}</a>
 			{% endif %}
 		{% endif %}
 
@@ -20,7 +20,7 @@
 
 		{% if entries.has_next %}
 			{% if entries.next_page_number != entries.paginator.num_pages %}
-				<a href="{{ base_url }}{{ entries.next_page_number }}/">{{ entries.next_page_number }}</a>
+				<a rel="next" href="{{ base_url }}{{ entries.next_page_number }}/">{{ entries.next_page_number }}</a>
 				{% if entries.next_page_number|add:"1" != entries.paginator.num_pages %}
 					{% if entries.next_page_number == entries.paginator.num_pages|add:"-2" %}
 						<a href="{{ base_url }}{{ entries.paginator.num_pages|add:"-1" }}/">{{ entries.paginator.num_pages|add:"-1" }}</a>
@@ -28,8 +28,10 @@
 						<span>…</span>
 					{% endif %}
 				{% endif %}
+			        <a href="{{ base_url }}{{ entries.paginator.num_pages }}/">{{ entries.paginator.num_pages }}</a>
+			{% else %}
+			        <a rel="next" href="{{ base_url }}{{ entries.paginator.num_pages }}/">{{ entries.paginator.num_pages }}</a>
 			{% endif %}
-			<a href="{{ base_url }}{{ entries.paginator.num_pages }}/">{{ entries.paginator.num_pages }}</a>
 		{% endif %}
 	{% endif %}
 {% endspaceless %}


### PR DESCRIPTION
This help people using keyboard navigation or with disabilities to
easily browse through pagination. For example, in Vimium, I can do `[[`
or `]]` to browse through the pages.

Not tested since it is quite a trivial change.
