### PR TITLE
Fix style for definition lists

### DIFF
--- a/scss/partials/_global.scss
+++ b/scss/partials/_global.scss
@@ -853,6 +853,13 @@ pre code {
 			}
 		}
 
+		dl {
+			dd {
+				padding-bottom: 0.5em;
+				padding-left: 1em;
+			}
+		}
+
 		blockquote {
 			border-left: 5px solid lighten($text, 75%);
 			padding-left: 10px;


### PR DESCRIPTION
Add a small padding to the left to match the expected presentation of a
definition list. Also add a padding similar to a paragraph at the bottom
to separate from the next entry.