### PR TITLE
Let logging play well with Sentry

### DIFF
--- a/feedhq/feeds/management/commands/clean_rq.py
+++ b/feedhq/feeds/management/commands/clean_rq.py
@@ -33,4 +33,4 @@ class Command(SentryCommand):
                 if date < delay:
                     r.delete(key)
                     count += 1
-        logger.info("Cleaned {0} jobs".format(count))
+        logger.info("Cleaned %s jobs", count)

--- a/feedhq/feeds/management/commands/sync_pubsubhubbub.py
+++ b/feedhq/feeds/management/commands/sync_pubsubhubbub.py
@@ -22,7 +22,7 @@ class Command(SentryCommand):
             ) and s.lease_expiration >= current_timestamp
             """))
         if len(extra):
-            logger.info("Unsubscribing from {0} feeds".format(len(extra)))
+            logger.info("Unsubscribing from %s feeds", len(extra))
             for subscription in extra:
                 try:
                     subscription.unsubscribe()

--- a/feedhq/feeds/management/commands/sync_scheduler.py
+++ b/feedhq/feeds/management/commands/sync_scheduler.py
@@ -26,13 +26,13 @@ class Command(SentryCommand):
         to_delete = existing_jobs - target
         if to_delete:
             logger.info(
-                "Deleting {0} jobs from the scheduler".format(len(to_delete)))
+                "Deleting %s jobs from the scheduler", len(to_delete))
             for job_id in to_delete:
                 delete_job(job_id, connection=connection)
 
         to_add = target - existing_jobs
         if to_add:
-            logger.info("Adding {0} jobs to the scheduler".format(len(to_add)))
+            logger.info("Adding %s jobs to the scheduler", len(to_add))
             for chunk in chunked(to_add, 10000):
                 uniques = UniqueFeed.objects.filter(url__in=chunk)
                 for unique in uniques:

--- a/feedhq/feeds/management/commands/updatefeeds.py
+++ b/feedhq/feeds/management/commands/updatefeeds.py
@@ -41,8 +41,8 @@ class Command(SentryCommand):
             queue = Queue(name=name, connection=conn)
             if queue.count > limit:
                 logger.info(
-                    "{0} queue longer than limit, skipping update "
-                    "({1} > {2})".format(name, queue.count, limit))
+                    "%s queue longer than limit, skipping update "
+                    "(%s > %s)", name, queue.count, limit)
                 return
 
         jobs = pending_jobs(limit=limit,

--- a/feedhq/feeds/models.py
+++ b/feedhq/feeds/models.py
@@ -194,7 +194,7 @@ class UniqueFeedManager(models.Manager):
             self.backoff_feed(url, error, backoff_factor)
             return
         except LocationParseError:
-            logger.debug(u"Failed to parse URL for {0}".format(url))
+            logger.debug(u"Failed to parse URL for %s", url)
             self.mute_feed(url, UniqueFeed.PARSE_ERROR)
             return
 
@@ -222,7 +222,7 @@ class UniqueFeedManager(models.Manager):
         update = {'last_update': int(time.time())}
 
         if response.status_code == 410:
-            logger.debug(u"Feed gone, {0}".format(url))
+            logger.debug(u"Feed gone, %s", url)
             self.mute_feed(url, UniqueFeed.GONE)
             return
 
@@ -231,7 +231,7 @@ class UniqueFeedManager(models.Manager):
             return
 
         elif response.status_code not in [200, 204, 304]:
-            logger.debug(u"{0} returned {1}".format(url, response.status_code))
+            logger.debug(u"%s returned %s", url, response.status_code)
 
             if response.status_code == 429:
                 # Too Many Requests
@@ -275,7 +275,7 @@ class UniqueFeedManager(models.Manager):
             else:
                 content = response.content
         except socket.timeout:
-            logger.debug(u'{0} timed out'.format(url))
+            logger.debug(u'%s timed out', url)
             self.backoff_feed(url, UniqueFeed.TIMEOUT, backoff_factor)
             return
 
@@ -386,7 +386,7 @@ class UniqueFeedManager(models.Manager):
         return entry_date, date_generated
 
     def handle_redirection(self, old_url, new_url):
-        logger.debug(u"{0} moved to {1}".format(old_url, new_url))
+        logger.debug(u"%s moved to %s", old_url, new_url)
         Feed.objects.filter(url=old_url).update(url=new_url)
         unique, created = self.get_or_create(url=new_url)
         if created:
@@ -402,9 +402,7 @@ class UniqueFeedManager(models.Manager):
 
     def backoff_feed(self, url, error, backoff_factor):
         if backoff_factor == UniqueFeed.MAX_BACKOFF - 1:
-            logger.debug(u"{0} reached max backoff period ({1})".format(
-                url, error,
-            ))
+            logger.debug(u"%s reached max backoff period (%s)", url, error)
         backoff_factor = min(UniqueFeed.MAX_BACKOFF, backoff_factor + 1)
         schedule_job(url, schedule_in=UniqueFeed.delay(backoff_factor),
                      error=error, backoff_factor=backoff_factor,

--- a/feedhq/feeds/tasks.py
+++ b/feedhq/feeds/tasks.py
@@ -63,7 +63,7 @@ def ensure_subscribed(topic_url, hub_url):
     try:
         s = Subscription.objects.get(topic=topic_url, hub=hub_url)
     except Subscription.DoesNotExist:
-        logger.debug(u"Subscribing to {0} via {1}".format(topic_url, hub_url))
+        logger.debug(u"Subscribing to %s via %s", topic_url, hub_url)
         call = Subscription.objects.subscribe
         args = topic_url, hub_url
     else:
@@ -71,7 +71,7 @@ def ensure_subscribed(topic_url, hub_url):
             not s.verified or
             s.lease_expiration < timezone.now() + timedelta(days=1)
         ):
-            logger.debug(u"Renewing subscription {0}".format(s.pk))
+            logger.debug(u"Renewing subscription %s", s.pk)
             call = s.subscribe
     if call is not None:
         call(*args)

--- a/feedhq/feeds/views.py
+++ b/feedhq/feeds/views.py
@@ -602,8 +602,8 @@ def import_feeds(request):
                     imported = save_outline(request.user, None, entries,
                                             existing_feeds)
             except ValidationError:
-                logger.info("Prevented duplicate import for user {0}".format(
-                    request.user.pk))
+                logger.info("Prevented duplicate import for user %s",
+                    request.user.pk)
             else:
                 message = " ".join([ungettext(
                     u'%s feed has been imported.',

--- a/feedhq/reader/views.py
+++ b/feedhq/reader/views.py
@@ -185,7 +185,7 @@ class ReaderView(APIView):
             token = request.DATA.get('T', request.GET.get('T', None))
             if token is None:
                 logger.info(
-                    u"Missing POST token, {0}".format(request.DATA.dict())
+                    u"Missing POST token, %s", request.DATA.dict()
                 )
                 raise exceptions.ParseError("Missing 'T' POST token")
             user_id = check_post_token(token)
@@ -555,9 +555,9 @@ class EditSubscription(ReaderView):
             if query:
                 qs.update(**query)
         else:
-            msg = u"Unrecognized action: {0}".format(action)
-            logger.info(msg)
-            raise exceptions.ParseError(msg)
+            msg = u"Unrecognized action: %s"
+            logger.info(msg, action)
+            raise exceptions.ParseError(msg % action)
         return Response("OK")
 edit_subscription = EditSubscription.as_view()
 
@@ -640,10 +640,10 @@ def get_es_term(stream, user, exception=False):
         [category] = categories
         term = {'category': category}
     else:
-        msg = u"Unrecognized stream: {0}".format(stream)
-        logger.info(msg)
+        msg = u"Unrecognized stream: %s"
+        logger.info(msg, stream)
         if exception:
-            raise exceptions.ParseError(msg)
+            raise exceptions.ParseError(msg % stream)
     return term
 
 
@@ -669,10 +669,10 @@ def get_q(stream, user, exception=False):
         name = is_label(stream, user.pk)
         stream_q = Q(feed__category__name=name)
     else:
-        msg = u"Unrecognized stream: {0}".format(stream)
-        logger.info(msg)
+        msg = u"Unrecognized stream: %s"
+        logger.info(msg, stream)
         if exception:
-            raise exceptions.ParseError(msg)
+            raise exceptions.ParseError(msg % stream)
     return stream_q
 
 
@@ -1175,7 +1175,7 @@ class EditTag(ReaderView):
                 continue
 
             else:
-                logger.info(u"Unhandled tag {0}".format(tag))
+                logger.info(u"Unhandled tag %s", tag)
                 raise exceptions.ParseError(
                     "Unrecognized tag: {0}".format(tag))
 
@@ -1191,7 +1191,7 @@ class EditTag(ReaderView):
                 continue
 
             else:
-                logger.info(u"Unhandled tag {0}".format(tag))
+                logger.info(u"Unhandled tag %s", tag)
                 raise exceptions.ParseError(
                     "Unrecognized tag: {0}".format(tag))
 
@@ -1252,10 +1252,10 @@ class MarkAllAsRead(ReaderView):
             elif state in ['starred', 'broadcast']:
                 es_entries = es_entries.filter(**{state: True})
             else:
-                logger.info(u"Unknown state: {0}".format(state))
+                logger.info(u"Unknown state: %s", state)
                 return Response("OK")
         else:
-            logger.info(u"Unknown stream: {0}".format(stream))
+            logger.info(u"Unknown stream: %s", stream)
             return Response("OK")
 
         entries = es_entries.aggregate('id').fetch(per_page=0)


### PR DESCRIPTION
Sentry opens a new issue for each value of "Cleaned {0} jobs".

Group similar errors under a unique logger message, let logging do the interpolation later (or not, if settings.LOGGING
silences debug messages).

By the way, this is not strictly necessary for debug messages but better be consistent.