### PR TITLE
Fixed Django ungettext 3rd parm

### DIFF
--- a/feedhq/feeds/views.py
+++ b/feedhq/feeds/views.py
@@ -142,13 +142,13 @@ def entries_list(request, page=1, mode=None, category=None, feed=None,
                 pks = form.save()
                 undo_form = loader.render_to_string('feeds/undo_read.html', {
                     'form': UndoReadForm(initial={
-                        'pks': json.dumps(pks, separators=(',', ':'))}),
+                    'pks': json.dumps(pks, separators=(',', ':'))}),
                     'action': request.get_full_path(),
                 }, context_instance=RequestContext(request))
                 message = ungettext(
                     '1 entry has been marked as read.',
                     '%(value)s entries have been marked as read.',
-                    'value') % {'value': len(pks)}
+                    len(pks)) % {'value': len(pks)}
                 messages.success(request,
                                  format_html(u"{0} {1}", message, undo_form))
 
@@ -160,7 +160,7 @@ def entries_list(request, page=1, mode=None, category=None, feed=None,
                     request, ungettext(
                         '1 entry has been marked as unread.',
                         '%(value)s entries have been marked as unread.',
-                        'value') % {'value': count})
+                        count) % {'value': count})
 
         if mode == 'unread':
             return redirect(unread_url)


### PR DESCRIPTION
Fixed a bug caused when one would press "Mark as read":

```
2016-06-19 14:42:04,099 ERROR: Internal Server Error: /                                                                                                           
Traceback (most recent call last):                                                                                                                                
  File "/srv/feedhq/env/lib/python2.7/site-packages/django/core/handlers/base.py", line 132, in get_response                                       
    response = wrapped_callback(request, *callback_args, **callback_kwargs)                                                                                       
  File "./feedhq/decorators.py", line 13, in check_login                                                                                                          
    return view_callable(request, *args, **kwargs)                                                                                                                
  File "./feedhq/feeds/views.py", line 151, in entries_list                                                                                                       
    'value') % {'value': len(pks)}                                                                                                                                
  File "/srv/feedhq/env/lib/python2.7/site-packages/django/utils/translation/__init__.py", line 88, in ungettext                                   
    return _trans.ungettext(singular, plural, number)                                                                                                             
  File "/srv/feedhq/env/lib/python2.7/site-packages/django/utils/translation/trans_real.py", line 378, in ungettext                                
    return do_ntranslate(singular, plural, number, 'ungettext')                                                                                                   
  File "/srv/feedhq/env/lib/python2.7/site-packages/django/utils/translation/trans_real.py", line 355, in do_ntranslate                            
    return getattr(t, translation_function)(singular, plural, number)                                                                                             
  File "/usr/lib64/python2.7/gettext.py", line 411, in ungettext                                                                                                  
    tmsg = self._catalog[(msgid1, self.plural(n))]                                                                                                                
  File "<string>", line 1, in <lambda>                                                                                                                            
TypeError: not all arguments converted during string formatting
```