### PR TITLE
Support delta feeds

### DIFF
--- a/feedhq/feeds/models.py
+++ b/feedhq/feeds/models.py
@@ -166,6 +166,8 @@ class UniqueFeedManager(models.Manager):
             headers['If-Modified-Since'] = force_bytes(last_modified)
         if etag:
             headers['If-None-Match'] = force_bytes(etag)
+        if last_modified or etag:
+            headers['A-IM'] = 'feed'
 
         if settings.TESTS:
             # Make sure requests.get is properly mocked during tests
@@ -230,7 +232,7 @@ class UniqueFeedManager(models.Manager):
             self.backoff_feed(url, str(response.status_code), backoff_factor)
             return
 
-        elif response.status_code not in [200, 204, 304]:
+        elif response.status_code not in [200, 204, 226, 304]:
             logger.debug(u"%s returned %s", url, response.status_code)
 
             if response.status_code == 429:

--- a/feedhq/feeds/models.py
+++ b/feedhq/feeds/models.py
@@ -167,7 +167,7 @@ class UniqueFeedManager(models.Manager):
         if etag:
             headers['If-None-Match'] = force_bytes(etag)
         if last_modified or etag:
-            headers['A-IM'] = 'feed'
+            headers['A-IM'] = force_bytes('feed')
 
         if settings.TESTS:
             # Make sure requests.get is properly mocked during tests

--- a/tests/test_fetching.py
+++ b/tests/test_fetching.py
@@ -259,6 +259,7 @@ class UpdateTests(TestCase):
                 'Accept': feedparser.ACCEPT_HEADER,
                 'If-None-Match': b'etag',
                 'If-Modified-Since': b'1234',
+                'A-IM': b'feed',
             }, timeout=10, auth=None)
 
     @patch("requests.get")


### PR DESCRIPTION
Changes:

* Append `A-IM` erquest header when either `If-Modified-Since` or `If-None-Match` headers are set.
* Accept 226 IM Used as a pass condition.

Delta feeds (RFC3229+feed) only includes new entries added since the feed was fetched the last time. Saves bandwidth for feed servers and users alike. Means less processing as only new and modified entries are included in the feed. 