### PR TITLE
docs: use python3 in installation instructions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -72,10 +72,9 @@ Getting the code::
 
     git clone https://github.com/feedhq/feedhq.git
     cd feedhq
-    virtualenv -p python2 env
-    source env/bin/activate
-    add2virtualenv .
-    pip install -r requirements.txt
+    python3 -m venv --prompt feedhq venv
+    source venv/bin/activate
+    pip install .
 
 Elasticsearch version requirements:
 


### PR DESCRIPTION
In REAMDE we are already requiring "Python 3.4 or later" but the
installation instructions still use python2 and virtualenv. This patch
replaces the commands with python3 and venv counterparts.